### PR TITLE
Added resource timeout setting to recipe

### DIFF
--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -57,7 +57,8 @@ Phantom.prototype.execute = function (request, response) {
   }
   request.template.phantom.allowLocalFilesAccess = self.allowLocalFilesAccess
   request.template.phantom.settings = {
-    javascriptEnabled: request.template.phantom.blockJavaScript !== 'true'
+    javascriptEnabled: request.template.phantom.blockJavaScript !== 'true',
+    resourceTimeout: request.template.phantom.resourceTimeout
   }
 
   if (request.template.phantom.waitForJS) {

--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -31,6 +31,7 @@ var Phantom = function (reporter, definition) {
     width: {type: 'Edm.String'},
     height: {type: 'Edm.String'},
     printDelay: {type: 'Edm.Int32'},
+    resourceTimeout: {type: 'Edm.Int32'},
     customPhantomJS: {type: 'Edm.Boolean'},
     blockJavaScript: {type: 'Edm.Boolean'},
     waitForJS: {type: 'Edm.Boolean'}

--- a/public/js/phantom.template.model.js
+++ b/public/js/phantom.template.model.js
@@ -32,7 +32,7 @@
         isDirty: function() {
             return this.get("margin") != null || this.get("header") != null || this.get("footer") != null ||
                 this.get("width") != null || this.get("height") != null || this.get("orientation") !== "portrait" ||
-                this.get("format") !== "A4" || this.get("printDelay") || this.get("waitForJS") || this.get("blockJavaScript");
+                this.get("format") !== "A4" || this.get("printDelay") || this.get("waitForJS") || this.get("blockJavaScript") || this.get("resourceTimeout");
         },
         
         apiOverride: function(req) {
@@ -48,7 +48,8 @@
                     height: this.get("height") || "...",
                     printDelay: this.get("printDelay") || "...",
                     waitForJS: this.get("waitForJS") || "...",
-                    blockJavaScript: this.get("blockJavaScript") || "..."
+                    blockJavaScript: this.get("blockJavaScript") || "...",
+                    resourceTimeout: this.get("resourceTimeout") || "..."
                 };
         }
     });

--- a/public/templates/phantom-template.html
+++ b/public/templates/phantom-template.html
@@ -48,7 +48,7 @@
     <input type="text" class="form-control area-mini" placeholder="800" name="printDelay" value="{{:printDelay}}">
 
     <span class="side-title">Resource timeout (ms)</span>
-    <input type="text" class="form-control area-mini" placeholder="800" name="resourceTimeout" value="{{:resourceTimeout}}">
+    <input type="text" class="form-control area-mini" placeholder="1000" name="resourceTimeout" value="{{:resourceTimeout}}">
 
     <span class="side-title" title="window.PHANTOM_HTML_TO_PDF_READY=true;">Wait for printing trigger</span>
     <input type="checkbox" class="checkbox form-control area-mini" name="waitForJS" title="window.PHANTOM_HTML_TO_PDF_READY=true;" value="{{:waitForJS}}">

--- a/public/templates/phantom-template.html
+++ b/public/templates/phantom-template.html
@@ -47,6 +47,9 @@
     <span class="side-title">Print Delay (ms)</span>
     <input type="text" class="form-control area-mini" placeholder="800" name="printDelay" value="{{:printDelay}}">
 
+    <span class="side-title">Resource timeout (ms)</span>
+    <input type="text" class="form-control area-mini" placeholder="800" name="resourceTimeout" value="{{:resourceTimeout}}">
+
     <span class="side-title" title="window.PHANTOM_HTML_TO_PDF_READY=true;">Wait for printing trigger</span>
     <input type="checkbox" class="checkbox form-control area-mini" name="waitForJS" title="window.PHANTOM_HTML_TO_PDF_READY=true;" value="{{:waitForJS}}">
 


### PR DESCRIPTION
Added the resource timeout setting available in phantom-html-to-pdf to be used in config or UI.
config example:
```
client.render({
    template: { 
    	shortid: '41ly53C_2e',

    	phantom: {
                resourceTimeout: '18000',
                blockJavaScript: 'true',
            }
}}, function(err, response) {

});
```