### PR TITLE
add support for passing an object to margin setting

### DIFF
--- a/lib/phantom.js
+++ b/lib/phantom.js
@@ -117,7 +117,20 @@ Phantom.prototype.init = function () {
 
 Phantom.prototype.execute = function (request, response) {
   var self = this
+  var margin
+
   request.template.phantom = request.template.phantom || {}
+
+  margin = request.template.phantom.margin
+
+  if (margin) {
+    if (typeof margin === 'string') {
+      try {
+        // margin value should always be a string or object, never a number
+        margin = isNaN(parseInt(margin, 10)) ? JSON.parse(margin) : String(JSON.parse(margin))
+      } catch (e) {}
+    }
+  }
 
   request.template.phantom.paperSize = {
     width: request.template.phantom.width,
@@ -126,8 +139,9 @@ Phantom.prototype.execute = function (request, response) {
     footerHeight: request.template.phantom.footerHeight,
     format: request.template.phantom.format,
     orientation: request.template.phantom.orientation,
-    margin: request.template.phantom.margin
+    margin: margin
   }
+
   request.template.phantom.allowLocalFilesAccess = self.allowLocalFilesAccess
   request.template.phantom.settings = {
     javascriptEnabled: request.template.phantom.blockJavaScript !== 'true',


### PR DESCRIPTION
this should allow to apply a workaround for this [problem](https://forum.jsreport.net/topic/33/custom-header-footer-sizes-for-phantompdf-template), with this change we now have the ability to pass an object for margin setting ([as documented in phantomjs website](http://phantomjs.org/api/webpage/property/paper-size.html)), which allows a more grained control about margin in PDF.

<img width="1309" alt="captura de pantalla 2017-03-27 a las 7 28 43 p m" src="https://cloud.githubusercontent.com/assets/4262050/24383641/bab64d5e-1323-11e7-9553-b2f863428e77.png">

Note: i was not able to replicate the problem on OSX or in linux (powered by docker), i only see the error on jsreport playground 
