### PR TITLE
Test with node from 8 to 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
   - "8"
+  - "10"
+  - "12"
+  - "14"
+  - "16"


### PR DESCRIPTION
to adress https://github.com/jsreport/jsreport-phantom-pdf/issues/39

Node 8 and 10 are no longer LTS and should probably be skipped but I don't know what is the support policy of jsreport regarding node so I keep them.